### PR TITLE
Add blog slider and pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,8 @@ import Gallery from './pages/Gallery';
 import Testimonials from './pages/Testimonials';
 import Contact from './pages/Contact';
 import About from './pages/About';
+import Blogs from './pages/Blogs';
+import Blog from './pages/Blog';
 import TermsAndConditions from './pages/termsandconditions';
 import Returns from './pages/returns';
 import Policy from './pages/Policy';
@@ -125,6 +127,8 @@ function App() {
         <Route path="/testomonials" element={<Testimonials />} />
         <Route path="/contact-us" element={<Contact />} />
         <Route path="/about-us" element={<About />} />
+        <Route path="/blogs" element={<Blogs />} />
+        <Route path="/blog/:id" element={<Blog />} />
         <Route path="/terms" element={<TermsAndConditions />} />
         <Route path="/returns" element={<Returns />} />
         <Route path="/policy" element={<Policy />} />

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import Header from './Header';
+import Footer from './Footer';
+import { useParams } from 'react-router-dom';
+
+export default function Blog() {
+  const { id } = useParams();
+  const [post, setPost] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPost = async () => {
+      try {
+        const res = await fetch(
+          `https://thealcworld.in/store/wp-json/wp/v2/posts/${id}?_embed`
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setPost(data);
+        }
+      } catch (err) {
+        console.error('Failed to load post', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPost();
+  }, [id]);
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-50 to-gray-100">
+      <Header />
+      <main className="flex-grow max-w-3xl mx-auto p-4">
+        {loading ? (
+          <p className="text-center">Loading...</p>
+        ) : post ? (
+          <article className="prose lg:prose-lg max-w-none">
+            <h1 dangerouslySetInnerHTML={{ __html: post.title.rendered }} />
+            {post._embedded?.['wp:featuredmedia']?.[0]?.source_url && (
+              <img
+                src={post._embedded['wp:featuredmedia'][0].source_url}
+                alt=""
+                className="w-full h-auto mb-4"
+              />
+            )}
+            <div dangerouslySetInnerHTML={{ __html: post.content.rendered }} />
+          </article>
+        ) : (
+          <p className="text-center">Post not found.</p>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/Blogs.jsx
+++ b/src/pages/Blogs.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import Header from './Header';
+import Footer from './Footer';
+import { Link } from 'react-router-dom';
+
+export default function Blogs() {
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        const res = await fetch(
+          'https://thealcworld.in/store/wp-json/wp/v2/posts?_embed&per_page=20'
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setPosts(data);
+        }
+      } catch (err) {
+        console.error('Failed to load posts', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPosts();
+  }, []);
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gradient-to-b from-gray-50 to-gray-100">
+      <Header />
+      <main className="flex-grow max-w-5xl mx-auto p-4">
+        <h1 className="text-3xl font-bold mb-8 text-center">Blogs</h1>
+        {loading ? (
+          <p className="text-center">Loading...</p>
+        ) : (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {posts.map((post) => {
+              const image =
+                post._embedded?.['wp:featuredmedia']?.[0]?.source_url;
+              return (
+                <Link
+                  key={post.id}
+                  to={`/blog/${post.id}`}
+                  className="block bg-white rounded-xl shadow hover:shadow-lg overflow-hidden transition"
+                >
+                  {image && (
+                    <img
+                      src={image}
+                      alt=""
+                      className="h-48 w-full object-cover"
+                    />
+                  )}
+                  <div className="p-4">
+                    <h2 className="font-semibold text-lg mb-2" dangerouslySetInnerHTML={{ __html: post.title.rendered }} />
+                    <div
+                      className="text-sm text-gray-600"
+                      dangerouslySetInnerHTML={{ __html: post.excerpt.rendered }}
+                    />
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/Footer.jsx
+++ b/src/pages/Footer.jsx
@@ -85,7 +85,7 @@ export default function Footer() {
               <FooterLink to="/about-us">About Us</FooterLink>
               <FooterLink to="/contact-us">Contact Us</FooterLink>
               <FooterLink to="/courses">Webinars</FooterLink>
-              <FooterLink href="https://thealcworld.in/store/">Blogs</FooterLink>
+              <FooterLink to="/blogs">Blogs</FooterLink>
             </ul>
           </div>
 

--- a/src/pages/Header.jsx
+++ b/src/pages/Header.jsx
@@ -81,6 +81,7 @@ export default function Header() {
               <NavLink to="/about-us" scrolled={scrolled}>About Us</NavLink>
               <NavLink to="/courses" scrolled={scrolled}>Webinars</NavLink>
               <NavLink to="/gallery" scrolled={scrolled}>Gallery</NavLink>
+              <NavLink to="/blogs" scrolled={scrolled}>Blogs</NavLink>
               <NavLink to="/testomonials" scrolled={scrolled}>Testimonials</NavLink>
               <NavLink to="/contact-us" scrolled={scrolled}>Contact Us</NavLink>
               <a 
@@ -186,6 +187,7 @@ export default function Header() {
               <MobileNavLink to="/about-us">About Us</MobileNavLink>
               <MobileNavLink to="/courses">Webinars</MobileNavLink>
               <MobileNavLink to="/gallery">Gallery</MobileNavLink>
+              <MobileNavLink to="/blogs">Blogs</MobileNavLink>
               <MobileNavLink to="/testomonials">Testimonials</MobileNavLink>
               <MobileNavLink to="/contact-us">Contact Us</MobileNavLink>
               <a 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -114,6 +114,25 @@ const Home = () => {
           </div>
         </div>
       </section>
+
+      {/* Blog Slider Section */}
+      <section className="py-20 px-4 relative z-10 bg-gradient-to-r from-gray-800/20 to-gray-900/20">
+        <div className="max-w-7xl mx-auto">
+          <div className="text-center mb-12">
+            <h2 className="text-3xl md:text-4xl font-bold mb-4">
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 to-yellow-500">
+                Latest Blogs
+              </span>
+            </h2>
+            <p className="text-lg text-gray-400 max-w-3xl mx-auto">
+              Insights and updates from Active Learning Company
+            </p>
+            <div className="w-24 h-1 bg-amber-500 mx-auto rounded-full mt-6"></div>
+          </div>
+
+          <BlogSlider />
+        </div>
+      </section>
       
       {/* Moving Social Lower Third */}
       <div className="fixed bottom-0 left-0 right-0 z-40 bg-gradient-to-r from-gray-900 to-black py-3 overflow-hidden">
@@ -1262,3 +1281,83 @@ const HomePage = () => {
 };
 
 export default HomePage;
+
+const BlogSlider = () => {
+  const [posts, setPosts] = useState([]);
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        const res = await fetch(
+          'https://thealcworld.in/store/wp-json/wp/v2/posts?_embed&per_page=5'
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setPosts(data);
+        }
+      } catch (err) {
+        console.error('Failed to load blog posts', err);
+      }
+    };
+    fetchPosts();
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrent((p) => (p + 1) % posts.length);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [posts.length]);
+
+  if (!posts.length) return null;
+
+  return (
+    <div className="relative overflow-hidden">
+      <div
+        className="flex transition-transform duration-700"
+        style={{ transform: `translateX(-${current * 100}%)` }}
+      >
+        {posts.map((post) => {
+          const image =
+            post._embedded?.['wp:featuredmedia']?.[0]?.source_url;
+          return (
+            <a
+              key={post.id}
+              href={`/blog/${post.id}`}
+              className="w-full flex-shrink-0 px-3"
+            >
+              <div className="bg-white rounded-xl shadow overflow-hidden">
+                {image && (
+                  <img
+                    src={image}
+                    alt=""
+                    className="h-56 w-full object-cover"
+                  />
+                )}
+                <div className="p-4">
+                  <h3
+                    className="font-semibold mb-2"
+                    dangerouslySetInnerHTML={{ __html: post.title.rendered }}
+                  />
+                </div>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+
+      <div className="flex justify-center mt-4">
+        {posts.map((_, idx) => (
+          <button
+            key={idx}
+            onClick={() => setCurrent(idx)}
+            className={`w-3 h-3 mx-1 rounded-full ${
+              current === idx ? 'bg-amber-500' : 'bg-gray-500'
+            }`}
+          ></button>
+        ))}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add routes for blogs
- create blog list and detail pages
- show new Blogs link in header and footer
- display latest blogs slider on the homepage

## Testing
- `npm run lint` *(fails: no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_686f7fb72954832f8200282d36915bbc